### PR TITLE
Add v1.3.0 taxonomy updates with new model structure

### DIFF
--- a/active-projects/MM -- Area + Sub-Area Taxonomy/areas_v1.3.yaml
+++ b/active-projects/MM -- Area + Sub-Area Taxonomy/areas_v1.3.yaml
@@ -1,0 +1,58 @@
+version: 1.3.0
+generated:
+  date: "2025-08-30"
+  authors:
+    - "Rodney Rothman (Modern Magic) — taxonomy owner"
+    - "Drafting assistant: GPT-5 Pro"
+  notes: >
+    Canonical 8 Areas for Modern Magic. Sub-areas are defined in sub_areas.yaml.
+    IDs are stable; names may change; codes are used in analytics and Notion/Select options.
+areas:
+  - id: CREATIVE_PROJECTS
+    code: CP
+    name: "Creative Projects"
+    status: active
+    sort: 10
+    description: "Owns creative origination/vetting, title development, and production lifecycle (DRI for ORIGIN and PROD phases)."
+  - id: TECHNOLOGY_AND_PIPELINE
+    code: TP
+    name: "Technology & Pipeline"
+    status: active
+    sort: 20
+    description: "Owns look-dev & pipeline R&D, show pipeline ops, and growth data instrumentation."
+  - id: TALENT_AND_CASTING
+    code: TA
+    name: "Talent Acquisition & Casting"
+    status: active
+    sort: 30
+    description: "Owns creator discovery, casting/voice, and studio recruitment (people pipeline)."
+  - id: PEOPLE_AND_CULTURE
+    code: PC
+    name: "People & Culture"
+    status: active
+    sort: 40
+    description: "Owns team development, culture/rituals, and HR/people operations."
+  - id: BUSINESS_AND_PARTNERSHIPS
+    code: BP
+    name: "Business & Partnerships"
+    status: active
+    sort: 50
+    description: "Owns partner origination, network/anchor relationships, distribution/JV/licensing, and portfolio strategy."
+  - id: FINANCE
+    code: FIN
+    name: "Finance"
+    status: active
+    sort: 60
+    description: "Owns fund finance, corporate FP&A, project financing, and investor relations."
+  - id: STUDIO_OPS_AND_LEGAL
+    code: SOL
+    name: "Studio Ops & Legal"
+    status: active
+    sort: 70
+    description: "Owns studio operations/PMO, legal/contracts/rights, compliance, and entity/cap-table management."
+  - id: MARKETING_AND_COMMUNITY
+    code: MC
+    name: "Marketing & Community"
+    status: active
+    sort: 80
+    description: "Owns brand/comms, marketing/publicity, and audience/community programs."

--- a/active-projects/MM -- Area + Sub-Area Taxonomy/phases_v1.3.yaml
+++ b/active-projects/MM -- Area + Sub-Area Taxonomy/phases_v1.3.yaml
@@ -1,0 +1,60 @@
+version: 1.3.0
+generated:
+  date: "2025-08-30"
+  authors:
+    - "Rodney Rothman (Modern Magic) — taxonomy owner"
+    - "Drafting assistant: GPT-5 Pro"
+  notes: >
+    Lifecycle is expressed as phases; each has a single DRI (sub-area code).
+    Phase names may change but IDs remain stable. DISCOVER is named 'Origin' to match mental model.
+    G_ORIGIN_APPROVED supersedes G_DEV_APPROVED (kept as legacy alias).
+
+phases:
+  - id: DISCOVER
+    name: "Origin (Talent/Idea Scouting & Vetting)"
+    dri: CP-ORIG
+    partners: [TA-DISCOVER, BP-NET, SOL-LEGAL]
+    exit_gate: G_ORIGIN_APPROVED
+    legacy_exit_gates: [G_DEV_APPROVED]
+    evidence_required:
+      - "Origination brief (concept, audience/fit thesis)"
+      - "Talent match confirmed (creator/team/partner)"
+      - "Rights availability or option viability"
+
+  - id: DEV
+    name: "Creative Development"
+    dri: CP-DEV
+    partners: [TP-RND, TA-CAST]
+    exit_gate: G_GREENLIGHT
+    evidence_required:
+      - "Creative lock (brief/script v1)"
+      - "Initial budget & schedule"
+      - "Lead(s) attached"
+      - "Financing path identified (Feeder or Typical)"
+
+  - id: DEALS
+    name: "Project Financing & Distribution"
+    dri: FIN-PROJ
+    co_dri: BP-DEALS
+    partners: [SOL-LEGAL, SOL-ENTITY]
+    exit_gate: G_FUNDED
+    evidence_required:
+      - "Funds committed / facility documented"
+      - "Distribution window/route committed"
+      - "LLC/SPV formed"
+
+  - id: PROD
+    name: "Production"
+    dri: CP-PROD
+    partners: [TP-OPS, TP-RND]
+    exit_gate: G_DELIVERED
+    evidence_required:
+      - "Contractual delivery achieved (episode/film/trailer/assets)"
+
+  - id: RELEASE
+    name: "Release & Growth"
+    dri: MC-COMMUNITY
+    partners: [MC-MKT, MC-BRAND, TP-DATA, FIN-CORP]
+    exit_gate: G_POST_EVAL
+    evidence_required:
+      - "30–90d KPI review and Tier decision (Kill/Prove/Scale/Franchise)"

--- a/active-projects/MM -- Area + Sub-Area Taxonomy/sub_areas_v1.3.yaml
+++ b/active-projects/MM -- Area + Sub-Area Taxonomy/sub_areas_v1.3.yaml
@@ -1,0 +1,216 @@
+version: 1.3.0
+generated:
+  date: "2025-08-30"
+  authors:
+    - "Rodney Rothman (Modern Magic) — taxonomy owner"
+    - "Drafting assistant: GPT-5 Pro"
+  notes: >
+    Sub-areas reference parent Areas by 'parent'. `owns` provides one-line scope.
+    `exclusions` are hard boundaries to prevent overlap. `dri_in_phases` indicates
+    lifecycle ownership (see phases.yaml).
+
+sub_areas:
+  # Creative Projects
+  - id: CP-ORIG
+    code: CP-ORIG
+    name: "Creative Origination & Vetting"
+    parent: CREATIVE_PROJECTS
+    owns: "Incoming/outbound pitches, internal concept generation, editorial pairing/matching of ideas with talent; prepares the origination brief"
+    exclusions: ["People pipeline (TA-DISCOVER)", "Partner network negotiations (BP-NET)", "Final option execution (SOL-LEGAL)"]
+    dri_in_phases: ["DISCOVER"]
+  - id: CP-DEV
+    code: CP-DEV
+    name: "Dev Slate (Pre-Greenlight)"
+    parent: CREATIVE_PROJECTS
+    owns: "Turn the selected concept/team into a greenlight-ready package (brief/script, budget/schedule v1, leads attached, financing path)"
+    exclusions: ["People pipeline (TA-DISCOVER)", "Campaign execution (MC)", "Partner sourcing (BP-NET)", "Final contracts (SOL-LEGAL)"]
+    dri_in_phases: ["DEV"]
+  - id: CP-PROD
+    code: CP-PROD
+    name: "Production Slate (Greenlit/Active)"
+    parent: CREATIVE_PROJECTS
+    owns: "Delivery of greenlit titles (production through post)"
+    exclusions: ["Financing (FIN-PROJ)", "Distribution/JV (BP-DEALS)", "Brand/comms (MC)"]
+    dri_in_phases: ["PROD"]
+
+  # Technology & Pipeline
+  - id: TP-RND
+    code: TP-RND
+    name: "Look-Dev & Pipeline R&D"
+    parent: TECHNOLOGY_AND_PIPELINE
+    owns: "New stylization, tools, and AI experiments to be validated for shows"
+    exclusions: ["Show ops (TP-OPS)", "Audience telemetry (TP-DATA)"]
+    dri_in_phases: []
+  - id: TP-OPS
+    code: TP-OPS
+    name: "Production Tech & Pipeline Ops"
+    parent: TECHNOLOGY_AND_PIPELINE
+    owns: "Show-level pipeline integration, render, DCC support"
+    exclusions: ["Strategic R&D (TP-RND)", "Campaign analytics (TP-DATA)"]
+    dri_in_phases: []
+  - id: TP-DATA
+    code: TP-DATA
+    name: "Growth Data & Instrumentation"
+    parent: TECHNOLOGY_AND_PIPELINE
+    owns: "Instrumentation across YT/TikTok/Discord/shop; KPI dashboards and experiment flags"
+    exclusions: ["Creative notes (CP-*)", "Deal terms (BP-*)"]
+    dri_in_phases: ["RELEASE"]
+
+  # Talent & Casting
+  - id: TA-DISCOVER
+    code: TA-DISCOVER
+    name: "Creator Discovery & Outreach"
+    parent: TALENT_AND_CASTING
+    owns: "Sourcing creators (writers/directors/artists), rosters, outreach, inbound triage by person"
+    exclusions: ["Concept vetting/pairing (CP-ORIG)", "Casting for specific roles (TA-CAST)"]
+    dri_in_phases: []
+  - id: TA-CAST
+    code: TA-CAST
+    name: "Casting & Voice Talent"
+    parent: TALENT_AND_CASTING
+    owns: "Casting process, availabilities, offers for voice and performance"
+    exclusions: ["Studio hiring (TA-HIRING)"]
+    dri_in_phases: []
+  - id: TA-HIRING
+    code: TA-HIRING
+    name: "Studio Hiring & Recruitment"
+    parent: TALENT_AND_CASTING
+    owns: "Reqs, pipelines, interviews, offers for internal roles"
+    exclusions: ["Casting (TA-CAST)"]
+    dri_in_phases: []
+
+  # People & Culture
+  - id: PC-DEV
+    code: PC-DEV
+    name: "Team Growth & Development"
+    parent: PEOPLE_AND_CULTURE
+    owns: "Leveling, learning programs, feedback cycles"
+    exclusions: []
+    dri_in_phases: []
+  - id: PC-CULTURE
+    code: PC-CULTURE
+    name: "Culture & Rituals"
+    parent: PEOPLE_AND_CULTURE
+    owns: "Norms, rituals, internal communications, engagement"
+    exclusions: []
+    dri_in_phases: []
+  - id: PC-PEOPLEOPS
+    code: PC-PEOPLEOPS
+    name: "HR & People Ops"
+    parent: PEOPLE_AND_CULTURE
+    owns: "Policies, onboarding, compensation process administration"
+    exclusions: ["Securities compliance (SOL-COMPLIANCE)"]
+    dri_in_phases: []
+
+  # Business & Partnerships
+  - id: BP-NET
+    code: BP-NET
+    name: "Network/Anchor Partner Portfolio"
+    parent: BUSINESS_AND_PARTNERSHIPS
+    owns: "Amplifier & anchor partner deals at portfolio-level and project network slot"
+    exclusions: ["Campaign execution (MC-*)", "Casting/hiring (TA-*)"]
+    dri_in_phases: []
+  - id: BP-BIZDEV
+    code: BP-BIZDEV
+    name: "Strategic Partners (Non-title)"
+    parent: BUSINESS_AND_PARTNERSHIPS
+    owns: "Non-title partner origination and relationship development"
+    exclusions: []
+    dri_in_phases: []
+  - id: BP-DEALS
+    code: BP-DEALS
+    name: "Distribution / JV / Co-Pro / Licensing"
+    parent: BUSINESS_AND_PARTNERSHIPS
+    owns: "Title/portfolio deals, rights windows, licensing structures"
+    exclusions: ["Final legal language (SOL-LEGAL)"]
+    dri_in_phases: ["DEALS"]
+  - id: BP-STRAT
+    code: BP-STRAT
+    name: "Company & Portfolio Strategy"
+    parent: BUSINESS_AND_PARTNERSHIPS
+    owns: "Market bets, slate architecture, international footprint"
+    exclusions: []
+    dri_in_phases: []
+
+  # Finance
+  - id: FIN-FUND
+    code: FIN-FUND
+    name: "Fund & Portfolio Finance"
+    parent: FINANCE
+    owns: "$25M fund accounting, waterfalls, SPV/LLC capitalization, investor reporting"
+    exclusions: ["Project budgets (FIN-PROJ)"]
+    dri_in_phases: []
+  - id: FIN-CORP
+    code: FIN-CORP
+    name: "Corporate Finance & FP&A"
+    parent: FINANCE
+    owns: "Corporate budgets, runway, reporting"
+    exclusions: ["Fund finance (FIN-FUND)", "Project financing (FIN-PROJ)"]
+    dri_in_phases: []
+  - id: FIN-PROJ
+    code: FIN-PROJ
+    name: "Project Financing"
+    parent: FINANCE
+    owns: "Title budgets, tax credits, loans, equity, cash-flow facilities"
+    exclusions: ["Distribution/licensing terms (BP-DEALS)"]
+    dri_in_phases: ["DEALS"]
+  - id: FIN-IR
+    code: FIN-IR
+    name: "Investor Relations"
+    parent: FINANCE
+    owns: "Investor updates, board materials, fundraising"
+    exclusions: []
+    dri_in_phases: []
+
+  # Studio Ops & Legal
+  - id: SOL-OPS
+    code: SOL-OPS
+    name: "Studio Operations & PMO"
+    parent: STUDIO_OPS_AND_LEGAL
+    owns: "Facilities, IT, SOPs, project management standards"
+    exclusions: []
+    dri_in_phases: []
+  - id: SOL-LEGAL
+    code: SOL-LEGAL
+    name: "Legal & Rights"
+    parent: STUDIO_OPS_AND_LEGAL
+    owns: "Options, agreements, chain of title, rights management"
+    exclusions: ["Securities/regulatory compliance (SOL-COMPLIANCE)", "Entity setup (SOL-ENTITY)"]
+    dri_in_phases: ["DEALS"]
+  - id: SOL-COMPLIANCE
+    code: SOL-COMPLIANCE
+    name: "Governance & Securities Compliance"
+    parent: STUDIO_OPS_AND_LEGAL
+    owns: "Reg D/blue-sky, privacy, labor, security compliance"
+    exclusions: []
+    dri_in_phases: []
+  - id: SOL-ENTITY
+    code: SOL-ENTITY
+    name: "Entity & Rights Management"
+    parent: STUDIO_OPS_AND_LEGAL
+    owns: "LLC/SPV formation, cap tables, EINs, rights registry"
+    exclusions: ["Contract lawyering (SOL-LEGAL)"]
+    dri_in_phases: ["DEALS"]
+
+  # Marketing & Community
+  - id: MC-MKT
+    code: MC-MKT
+    name: "Marketing & Publicity"
+    parent: MARKETING_AND_COMMUNITY
+    owns: "Campaigns, assets, press"
+    exclusions: ["Partner dealmaking (BP-*)", "KPI instrumentation (TP-DATA)"]
+    dri_in_phases: ["RELEASE"]
+  - id: MC-BRAND
+    code: MC-BRAND
+    name: "Brand & Communications"
+    parent: MARKETING_AND_COMMUNITY
+    owns: "Brand system, site, social voice, comms"
+    exclusions: []
+    dri_in_phases: ["RELEASE"]
+  - id: MC-COMMUNITY
+    code: MC-COMMUNITY
+    name: "Audience & Community"
+    parent: MARKETING_AND_COMMUNITY
+    owns: "Discord/newsletter/programming, UGC amplification, micro-influencer ops"
+    exclusions: ["Partner negotiations (BP-*)"]
+    dri_in_phases: ["RELEASE"]

--- a/active-projects/MM -- Area + Sub-Area Taxonomy/taxonomy_context_addendum_v1.3.md
+++ b/active-projects/MM -- Area + Sub-Area Taxonomy/taxonomy_context_addendum_v1.3.md
@@ -1,0 +1,10 @@
+# Context Addendum — v1.3.0
+
+**Change requested by Rodney:** Treat outreach to talent/incoming pitches and idea vetting as a **separate gate** before Development.
+**Resolution:** Introduced `CP-ORIG` (Creative Origination & Vetting) as DRI of the first phase and renamed the phase to **Origin** (ID stays `DISCOVER`).
+Gate `G_ORIGIN_APPROVED` now controls entry into Development (keeps legacy alias `G_DEV_APPROVED` for continuity).
+
+**Boundaries clarified:**
+- `TA-DISCOVER` owns **people pipeline** (rosters, outreach).  
+- `CP-ORIG` owns **concept pipeline** (pitches, internal ideas, matching ideas ↔ talent) and the editorial decision to proceed.  
+- Contract execution remains with `SOL-LEGAL` in DEALS; partner negotiations remain with `BP-*`.


### PR DESCRIPTION
- Add areas_v1.3.yaml with 8 canonical areas and codes
- Add phases_v1.3.yaml with DRI assignments and gates
- Add sub_areas_v1.3.yaml with detailed scope definitions
- Add taxonomy_context_addendum_v1.3.md documenting changes
- Introduces CP-ORIG sub-area and Origin phase rename
- Separates talent outreach (TA-DISCOVER) from concept vetting (CP-ORIG)

🤖 Generated with [Claude Code](https://claude.ai/code)